### PR TITLE
#4 example.com で E2E 動作確認

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,17 @@
 
 # === 第2層: Midscene Vision LLM（ブラウザ操作）===
 
-# --- パターン A: Ollama（ローカル、無料）---
-MIDSCENE_MODEL_NAME=qwen2.5-vl:7b
+# --- パターン A: Ollama + Qwen3.5（ローカル、無料、推奨）---
+MIDSCENE_MODEL_NAME=qwen3.5:9b
 MIDSCENE_MODEL_BASE_URL=http://localhost:11434/v1
 MIDSCENE_MODEL_API_KEY=ollama
-MIDSCENE_MODEL_FAMILY=qwen-vl
+MIDSCENE_MODEL_FAMILY=qwen3.5
+
+# --- パターン A2: Ollama + Qwen2.5-VL（旧バージョン）---
+# MIDSCENE_MODEL_NAME=qwen2.5-vl:7b
+# MIDSCENE_MODEL_BASE_URL=http://localhost:11434/v1
+# MIDSCENE_MODEL_API_KEY=ollama
+# MIDSCENE_MODEL_FAMILY=qwen-vl
 
 # --- パターン B: Google Gemini（低コスト）---
 # MIDSCENE_MODEL_NAME=gemini-2.5-flash

--- a/.taskp/config.toml
+++ b/.taskp/config.toml
@@ -2,7 +2,7 @@
 
 [ai]
 default_provider = "ollama"
-default_model = "qwen2.5-coder:7b"
+default_model = "qwen3.5:9b"
 
 [ai.providers.ollama]
 base_url = "http://localhost:11434/v1"

--- a/.taskp/skills/web-agent/SKILL.md
+++ b/.taskp/skills/web-agent/SKILL.md
@@ -68,6 +68,8 @@ mkdir -p {{__cwd__}}/.taskp-tmp
 - `bun run` でスクリプト実行する（tsx ではなく bun）
 - aiAct の指示は「今の画面を見ればわかる」レベルで具体的に書く（「さっきの」「それ」のような指示語は使えない）
 - `authDir` 配下にサイト名の JSON ファイル（例: `auth/example.json`）が存在する場合は `storageState` として使用する
+- **finally ブロックで `process.exit()` を必ず呼ぶ**こと（Midscene 内部タイマーでプロセスがハングするため）
+- `let exitCode = 0` を try の前に宣言し、catch で `exitCode = 1` に設定、finally で `process.exit(exitCode)` を呼ぶパターンを使う
 
 ### Step 2: スクリプトの実行
 

--- a/.taskp/skills/web-agent/templates/agent-runner.ts
+++ b/.taskp/skills/web-agent/templates/agent-runner.ts
@@ -43,6 +43,7 @@ const agent = new PlaywrightAgent(page, {
 	replanningCycleLimit: REPLANNING_CYCLE_LIMIT,
 });
 
+let exitCode = 0;
 try {
 	// === 操作 ===
 	// ここに LLM がユーザーの指示に応じた操作手順を書く
@@ -78,7 +79,8 @@ try {
 		// ブラウザクラッシュ等でスクショも撮れない場合は無視
 	}
 	console.error("❌ 操作失敗:", (error as Error).message);
-	throw error;
+	exitCode = 1;
 } finally {
 	await browser.close();
+	process.exit(exitCode);
 }


### PR DESCRIPTION
## Summary

Issue #4 の E2E 動作確認を実施し、発見した問題を修正。

## テスト結果

| # | テスト | 結果 |
|---|--------|------|
| 1 | 基本動作確認（スクショ+レポート生成） | ✅ Pass |
| 2 | データ抽出（JSON形式） | ✅ Pass |
| 3 | 完了後コマンド（after_command） | ✅ Pass |
| 4 | headed モード（headless=false） | ✅ Pass |
| 5 | --skip-prompt モード（cron想定） | ✅ Pass |

## 変更内容

### テンプレート修正 (`agent-runner.ts`)
- `process.exit()` を追加（Midscene 内部タイマーによるプロセスハング防止）
- `exitCode` パターンで正常/異常終了コードを一元管理（`browser.close()` 二重呼び出し・exit code 上書き問題を回避）

### SKILL.md 更新
- スクリプト生成時の重要ルールに `process.exit` 必須・`exitCode` パターンを追記

### .env.example 更新
- Ollama + Qwen3.5 を推奨パターン A として追加（Midscene 公式サポート確認済み）
- 旧 Qwen2.5-VL をパターン A2 に移動

### config.toml 更新
- デフォルトモデルを `qwen3.5:9b` に変更

Closes #4